### PR TITLE
Feature: Add configuration to override authorization endpoint

### DIFF
--- a/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
+++ b/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
@@ -214,7 +214,21 @@ public class OidcClient {
   protected OIDCProviderMetadata getProviderMetadata() {
     LOGGER.debug("Retrieving provider metadata from {}", config.issuerUri());
     try {
-      return OIDCProviderMetadata.resolve(new Issuer(config.issuerUri()));
+      // Load Metadata via Discovery
+      OIDCProviderMetadata metadata = OIDCProviderMetadata.resolve(new Issuer(config.issuerUri()));
+
+      // Override Authorization Endpoint if configured
+      config.authorizationEndpoint().ifPresent(customEndpoint -> {
+        if (!customEndpoint.trim().isEmpty()) {
+          try {
+            LOGGER.info("Overriding OIDC authorization endpoint: {}", customEndpoint);
+            metadata.setAuthorizationEndpointURI(new URI(customEndpoint));
+          } catch (URISyntaxException e) {
+            throw new IllegalStateException("The custom OIDC authorization endpoint URI is invalid: " + customEndpoint, e);
+          }
+        }
+      });
+      return metadata;
     } catch (IOException | GeneralException e) {
       if (e instanceof GeneralException && e.getMessage().contains("issuer doesn't match")) {
         throw new IllegalStateException("Retrieving OpenID Connect provider metadata failed: " +

--- a/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcConfiguration.java
+++ b/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcConfiguration.java
@@ -79,6 +79,8 @@ public class OidcConfiguration {
   static final String LOGIN_BUTTON_TEXT = PREFIX + ".loginButtonText";
   private static final String LOGIN_BUTTON_TEXT_DEFAULT_VALUE = "OpenID Connect";
 
+  public static final String AUTH_ENDPOINT = PREFIX + ".authorizationEndpoint";
+
   private final Configuration config;
 
   public OidcConfiguration(Configuration config) {
@@ -106,6 +108,10 @@ public class OidcConfiguration {
   @CheckForNull
   public String issuerUri() {
     return config.get(ISSUER_URI).orElse(null);
+  }
+
+  public Optional<String> authorizationEndpoint() {
+    return config.get(AUTH_ENDPOINT);
   }
 
   @CheckForNull
@@ -174,6 +180,9 @@ public class OidcConfiguration {
         PropertyDefinition.builder(ISSUER_URI).name("Issuer URI")
             .description("The issuer URI of an OpenID Connect provider. "
                 + "This URI is used to retrieve the provider's metadata via OpenID Connect Discovery from the path \"/.well-known/openid-configuration\".")
+            .category(CATEGORY).subCategory(SUBCATEGORY).type(STRING).index(index++).build(),
+        PropertyDefinition.builder(AUTH_ENDPOINT).name("Authorization Endpoint")
+            .description("Override the authorization endpoint URL if the one from .well-known/openid-configuration is not reachable or incorrect.")
             .category(CATEGORY).subCategory(SUBCATEGORY).type(STRING).index(index++).build(),
         PropertyDefinition.builder(CLIENT_ID).name("Client ID").description("The ID of an OpenID Connect Client.")
             .category(CATEGORY).subCategory(SUBCATEGORY).type(STRING).index(index++).build(),

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/AuthOidcPluginTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/AuthOidcPluginTest.java
@@ -33,7 +33,7 @@ public class AuthOidcPluginTest {
   public void test_server_side_extensions() throws Exception {
     Plugin.Context context = setupContext(SonarQubeSide.SERVER);
     underTest.define(context);
-    assertThat(context.getExtensions()).hasSize(20);
+    assertThat(context.getExtensions()).hasSize(21);
   }
 
   @Test

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcConfigurationTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcConfigurationTest.java
@@ -178,7 +178,7 @@ public class OidcConfigurationTest {
 
   @Test
   public void definitions() {
-    assertThat(OidcConfiguration.definitions()).hasSize(15);
+    assertThat(OidcConfiguration.definitions()).hasSize(16);
   }
 
   @Test


### PR DESCRIPTION
This PR adds a new configuration property sonar.auth.oidc.authorizationEndpoint.
It allows overriding the authorization endpoint URL discovered via the .well-known/openid-configuration. This is useful in network environments where the discovered URL is not reachable from the user's browser (e.g., due to proxies or internal/external URL mismatches).
Changes:

- Added AUTH_ENDPOINT property in OidcConfiguration.

- Implemented override logic in OidcClient.

- Updated Unit Tests to reflect the new property.