### PR TITLE
feature: allow custom authorization endpoint override

### DIFF
--- a/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
+++ b/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcClient.java
@@ -62,18 +62,17 @@ public class OidcClient {
   }
 
   public AuthenticationRequest createAuthenticationRequest(String callbackUrl, String state) {
-    AuthenticationRequest request;
     LOGGER.debug("Creating authentication request");
     OIDCProviderMetadata providerMetadata = getProviderMetadata();
     try {
-      Builder builder = new AuthenticationRequest.Builder(RESPONSE_TYPE, getScope(), getClientId(),
-          new URI(callbackUrl));
-      request = builder.endpointURI(providerMetadata.getAuthorizationEndpointURI()).state(State.parse(state)).build();
+      URI endpointUri = providerMetadata.getAuthorizationEndpointURI();
+      return new AuthenticationRequest.Builder(RESPONSE_TYPE, getScope(), getClientId(), new URI(callbackUrl))
+          .endpointURI(endpointUri)
+          .state(State.parse(state))
+          .build();
     } catch (URISyntaxException e) {
       throw new IllegalStateException("Creating new authentication request failed", e);
     }
-    LOGGER.debug("Authentication request URI: {}", request.toURI());
-    return request;
   }
 
   public AuthorizationCode getAuthorizationCode(HttpRequest callbackRequest) {
@@ -214,11 +213,23 @@ public class OidcClient {
   protected OIDCProviderMetadata getProviderMetadata() {
     LOGGER.debug("Retrieving provider metadata from {}", config.issuerUri());
     try {
-      return OIDCProviderMetadata.resolve(new Issuer(config.issuerUri()));
+      OIDCProviderMetadata metadata = OIDCProviderMetadata.resolve(new Issuer(config.issuerUri()));
+
+      config.authorizationEndpoint().ifPresent(customEndpoint -> {
+        if (!customEndpoint.trim().isEmpty()) {
+          try {
+            LOGGER.info("Overriding OIDC authorization endpoint: {}", customEndpoint);
+            metadata.setAuthorizationEndpointURI(new URI(customEndpoint));
+          } catch (URISyntaxException e) {
+            throw new IllegalStateException("The custom OIDC authorization endpoint URI is invalid: " + customEndpoint, e);
+          }
+        }
+      });
+      return metadata;
     } catch (IOException | GeneralException e) {
       if (e instanceof GeneralException && e.getMessage().contains("issuer doesn't match")) {
         throw new IllegalStateException("Retrieving OpenID Connect provider metadata failed: " +
-                "Issuer URL in provider metadata doesn't match the issuer URI specified in plugin configuration");
+            "Issuer URL in provider metadata doesn't match the issuer URI specified in plugin configuration");
       } else {
         throw new IllegalStateException("Retrieving OpenID Connect provider metadata failed", e);
       }

--- a/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcConfiguration.java
+++ b/src/main/java/org/vaulttec/sonarqube/auth/oidc/OidcConfiguration.java
@@ -79,6 +79,8 @@ public class OidcConfiguration {
   static final String LOGIN_BUTTON_TEXT = PREFIX + ".loginButtonText";
   private static final String LOGIN_BUTTON_TEXT_DEFAULT_VALUE = "OpenID Connect";
 
+  public static final String AUTH_ENDPOINT = PREFIX + ".authorizationEndpoint";
+
   private final Configuration config;
 
   public OidcConfiguration(Configuration config) {
@@ -106,6 +108,10 @@ public class OidcConfiguration {
   @CheckForNull
   public String issuerUri() {
     return config.get(ISSUER_URI).orElse(null);
+  }
+
+  public Optional<String> authorizationEndpoint() {
+    return config.get(AUTH_ENDPOINT);
   }
 
   @CheckForNull
@@ -174,6 +180,9 @@ public class OidcConfiguration {
         PropertyDefinition.builder(ISSUER_URI).name("Issuer URI")
             .description("The issuer URI of an OpenID Connect provider. "
                 + "This URI is used to retrieve the provider's metadata via OpenID Connect Discovery from the path \"/.well-known/openid-configuration\".")
+            .category(CATEGORY).subCategory(SUBCATEGORY).type(STRING).index(index++).build(),
+        PropertyDefinition.builder(AUTH_ENDPOINT).name("Authorization Endpoint")
+            .description("Override the authorization endpoint URL if the one from .well-known/openid-configuration is not reachable or incorrect.")
             .category(CATEGORY).subCategory(SUBCATEGORY).type(STRING).index(index++).build(),
         PropertyDefinition.builder(CLIENT_ID).name("Client ID").description("The ID of an OpenID Connect Client.")
             .category(CATEGORY).subCategory(SUBCATEGORY).type(STRING).index(index++).build(),

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/AbstractOidcTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/AbstractOidcTest.java
@@ -46,8 +46,8 @@ public abstract class AbstractOidcTest {
 
   @Before
   public void initConfig() {
-      when(config.get(any())).thenAnswer(invocation -> Optional.of(settings.get(invocation.getArgument(0))));
-      when(config.getBoolean(any())).thenAnswer(invocation -> Optional.of(Boolean.parseBoolean(settings.get(invocation.getArgument(0)))));
+    when(config.get(any())).thenAnswer(invocation -> Optional.ofNullable(settings.get(invocation.getArgument(0))));
+    when(config.getBoolean(any())).thenAnswer(invocation -> Optional.ofNullable(Boolean.parseBoolean(settings.get(invocation.getArgument(0)))));
   }
 
   protected void setSettings(boolean enabled) {

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/AuthOidcPluginTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/AuthOidcPluginTest.java
@@ -33,7 +33,7 @@ public class AuthOidcPluginTest {
   public void test_server_side_extensions() throws Exception {
     Plugin.Context context = setupContext(SonarQubeSide.SERVER);
     underTest.define(context);
-    assertThat(context.getExtensions()).hasSize(20);
+    assertThat(context.getExtensions()).hasSize(21);
   }
 
   @Test

--- a/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcConfigurationTest.java
+++ b/src/test/java/org/vaulttec/sonarqube/auth/oidc/OidcConfigurationTest.java
@@ -178,7 +178,7 @@ public class OidcConfigurationTest {
 
   @Test
   public void definitions() {
-    assertThat(OidcConfiguration.definitions()).hasSize(15);
+    assertThat(OidcConfiguration.definitions()).hasSize(16);
   }
 
   @Test


### PR DESCRIPTION
### Description
This PR introduces a new configuration property `sonar.auth.oidc.authEndpoint` to manually override the authorization endpoint URI.

### Motivation
While OIDC Discovery is great, some Identity Providers or proxies (like **Dex** with specific connectors) require additional path segments or query parameters (e.g., `/auth/microsoft`) that are not always present in the standard `.well-known/openid-configuration` response. 

Currently, there is no way to point the plugin to these specific endpoints if the discovery metadata returns a generic one. This change provides the necessary flexibility for such environments.

### Key Changes
- **OidcConfiguration**: Added `sonar.auth.oidc.authEndpoint` property and UI definition.
- **OidcClient**: Modified `getProviderMetadata()` to override the discovered authorization URI with the custom one if configured.
- **Testing**: Updated `AbstractOidcTest` to use `Optional.ofNullable` to ensure existing tests remain stable even with the new optional property.
- Updated AuthOidcPluginTest and OidcConfigurationTest to account for the new configuration property.

### Verification
- Ran all existing 68 tests (`mvn clean test`) -> All passed.
- Manually verified that the redirect to a custom path (Dex connector) works as expected.